### PR TITLE
Add Ryzen-specific patches from AMD_Vanilla and Mojave_AMD_XNU

### DIFF
--- a/osfmk/i386/commpage/commpage.c
+++ b/osfmk/i386/commpage/commpage.c
@@ -377,7 +377,7 @@ commpage_init_cpu_capabilities( void )
 		    CPUID_LEAF7_FEATURE_AVX512VBMI);
 	}
 
-	uint64_t misc_enable = rdmsr64(MSR_IA32_MISC_ENABLE);
+	uint64_t misc_enable = 0; // rdmsr64(MSR_IA32_MISC_ENABLE);
 	setif(bits, kHasENFSTRG, (misc_enable & 1ULL) &&
 	    (cpuid_leaf7_features() &
 	    CPUID_LEAF7_FEATURE_ERMS));

--- a/osfmk/i386/cpu_threads.c
+++ b/osfmk/i386/cpu_threads.c
@@ -1091,7 +1091,7 @@ x86_validate_topology(void)
 			TOPO_DBG("\n");
 
 			if (nCores != topoParms.nLCoresPerDie) {
-				panic("Should have %d Cores, but only found %d for Die %d",
+				kprintf("Should have %d Cores, but only found %d for Die %d",
 				    topoParms.nLCoresPerDie, nCores, die->pdie_num);
 			}
 
@@ -1117,7 +1117,7 @@ x86_validate_topology(void)
 			TOPO_DBG("\n");
 
 			if (nCPUs != topoParms.nLThreadsPerDie) {
-				panic("Should have %d Threads, but only found %d for Die %d",
+				kprintf("Should have %d Threads, but only found %d for Die %d",
 				    topoParms.nLThreadsPerDie, nCPUs, die->pdie_num);
 			}
 
@@ -1126,7 +1126,7 @@ x86_validate_topology(void)
 		}
 
 		if (nDies != topoParms.nLDiesPerPackage) {
-			panic("Should have %d Dies, but only found %d for package %d",
+			kprintf("Should have %d Dies, but only found %d for package %d",
 			    topoParms.nLDiesPerPackage, nDies, pkg->lpkg_num);
 		}
 
@@ -1169,7 +1169,7 @@ x86_validate_topology(void)
 			TOPO_DBG("\n");
 
 			if (nCPUs != topoParms.nLThreadsPerCore) {
-				panic("Should have %d Threads, but only found %d for Core %d",
+				kprintf("Should have %d Threads, but only found %d for Core %d",
 				    topoParms.nLThreadsPerCore, nCPUs, core->pcore_num);
 			}
 			nCores += 1;
@@ -1177,7 +1177,7 @@ x86_validate_topology(void)
 		}
 
 		if (nCores != topoParms.nLCoresPerPackage) {
-			panic("Should have %d Cores, but only found %d for package %d",
+			kprintf("Should have %d Cores, but only found %d for package %d",
 			    topoParms.nLCoresPerPackage, nCores, pkg->lpkg_num);
 		}
 
@@ -1202,7 +1202,7 @@ x86_validate_topology(void)
 		}
 
 		if (nCPUs != topoParms.nLThreadsPerPackage) {
-			panic("Should have %d Threads, but only found %d for package %d",
+			kprintf("Should have %d Threads, but only found %d for package %d",
 			    topoParms.nLThreadsPerPackage, nCPUs, pkg->lpkg_num);
 		}
 

--- a/osfmk/i386/cpu_topology.c
+++ b/osfmk/i386/cpu_topology.c
@@ -143,7 +143,7 @@ cpu_topology_sort(int ncpus)
 		x86_set_logical_topology(&cpup->lcpu, cpup->cpu_phys_number, i);
 	}
 
-	cpu_shadow_sort(ncpus);
+	// cpu_shadow_sort(ncpus);
 	x86_validate_topology();
 
 	ml_set_interrupts_enabled(istate);

--- a/osfmk/i386/cpuid.c
+++ b/osfmk/i386/cpuid.c
@@ -754,7 +754,7 @@ cpuid_set_generic_info(i386_cpu_info_t *info_p)
 	 * and bracket this with the approved procedure for reading the
 	 * the microcode version number a.k.a. signature a.k.a. BIOS ID
 	 */
-	wrmsr64(MSR_IA32_BIOS_SIGN_ID, 0);
+	// wrmsr64(MSR_IA32_BIOS_SIGN_ID, 0);
 	cpuid_fn(1, reg);
 	info_p->cpuid_microcode_version = 186;
 	    // (uint32_t) (rdmsr64(MSR_IA32_BIOS_SIGN_ID) >> 32);

--- a/osfmk/i386/cpuid.c
+++ b/osfmk/i386/cpuid.c
@@ -548,6 +548,127 @@ cpuid_set_cache_info( i386_cpu_info_t * info_p )
 	DBG("\n");
 }
 
+static void init_amd_erratas(i386_cpu_info_t* info_p)
+{
+    uint64_t msr;
+
+    // /*
+    //  * Work around Erratum 721 for Family 10h and 12h processors.
+    //  * These processors may incorrectly update the stack pointer
+    //  * after a long series of push and/or near-call instructions,
+    //  * or a long series of pop and/or near-return instructions.
+    //  *
+    //  * http://support.amd.com/us/Processor_TechDocs/41322_10h_Rev_Gd.pdf
+    //  * http://support.amd.com/us/Processor_TechDocs/44739_12h_Rev_Gd.pdf
+    //  *
+    //  * Hypervisors do not provide access to the errata MSR,
+    //  * causing #GP exception on attempt to apply the errata.  The
+    //  * MSR write shall be done on host and persist globally
+    //  * anyway, so do not try to do it when under virtualization.
+    //  */
+    //
+    // switch (info_p->cpuid_family) {
+    // case 0x10:
+    // case 0x12:
+    //     if ((info_p->cpuid_features & 0x80000000) == 0)
+    //         wrmsr64(0xc0011029, rdmsr64(0xc0011029) | 1);
+    //     break;
+    // }
+    //
+    // /*
+    //  * BIOS may fail to set InitApicIdCpuIdLo to 1 as it should per BKDG.
+    //  * So, do it here or otherwise some tools could be confused by
+    //  * Initial Local APIC ID reported with CPUID Function 1 in EBX.
+    //  */
+    // if (info_p->cpuid_family == 0x10) {
+    //     if ((info_p->cpuid_features & 0x80000000) == 0) {
+    //         msr = rdmsr64(0xc001001f);
+    //         msr |= (uint64_t)1 << 54;
+    //         wrmsr64(0xc001001f, msr);
+    //     }
+    // }
+    //
+    // /*
+    //  * BIOS may configure Family 10h processors to convert WC+ cache type
+    //  * to CD.  That can hurt performance of guest VMs using nested paging.
+    //  * The relevant MSR bit is not documented in the BKDG,
+    //  * the fix is borrowed from Linux.
+    //  */
+    // if (info_p->cpuid_family == 0x10) {
+    //     if ((info_p->cpuid_features & 0x80000000) == 0) {
+    //         msr = rdmsr64(0xc001102a);
+    //         msr &= ~((uint64_t)1 << 24);
+    //         wrmsr64(0xc001102a, msr);
+    //     }
+    // }
+    //
+    // /*
+    //  * Work around Erratum 793: Specific Combination of Writes to Write
+    //  * Combined Memory Types and Locked Instructions May Cause Core Hang.
+    //  * See Revision Guide for AMD Family 16h Models 00h-0Fh Processors,
+    //  * revision 3.04 or later, publication 51810.
+    //  */
+    // if (info_p->cpuid_family == 0x16 && info_p->cpuid_model <= 0xf) {
+    //     if ((info_p->cpuid_features & 0x80000000) == 0) {
+    //         msr = rdmsr64(0xc0011020);
+    //         msr |= (uint64_t)1 << 15;
+    //         wrmsr64(0xc0011020, msr);
+    //     }
+    // }
+    //
+    /* Ryzen erratas. */
+    // if (info_p->cpuid_family == 0x17 && info_p->cpuid_model == 0x1 && (info_p->cpuid_features & 0x80000000) == 0) {
+        /* 1021 */
+        msr = rdmsr64(0xc0011029);
+        msr |= 0x2000;
+        wrmsr64(0xc0011029, msr);
+
+        /* 1033 */
+        msr = rdmsr64(0xc0011020);
+        msr |= 0x10;
+        wrmsr64(0xc0011020, msr);
+
+        /* 1049 */
+        msr = rdmsr64(0xc0011028);
+        msr |= 0x10;
+        wrmsr64(0xc0011028, msr);
+
+        /* 1095 */
+        msr = rdmsr64(0xc0011020);
+        msr |= 0x200000000000000;
+        wrmsr64(0xc0011020, msr);
+    // }
+
+    // /*
+    //  * Work around a problem on Ryzen that is triggered by executing
+    //  * code near the top of user memory, in our case the signal
+    //  * trampoline code in the shared page on amd64.
+    //  *
+    //  * This function is executed once for the BSP before tunables take
+    //  * effect so the value determined here can be overridden by the
+    //  * tunable.  This function is then executed again for each AP and
+    //  * also on resume.  Set a flag the first time so that value set by
+    //  * the tunable is not overwritten.
+    //  *
+    //  * The stepping and/or microcode versions should be checked after
+    //  * this issue is fixed by AMD so that we don't use this mode if not
+    //  * needed.
+    //  */
+    // if (lower_sharedpage_init == 0) {
+    //     lower_sharedpage_init = 1;
+    //     if (info_p->cpuid_family == 0x17) {
+    //         hw_lower_amd64_sharedpage = 1;
+    //     }
+    // }
+    // amd64_lower_shared_page(struct sysentvec * sv) if (hw_lower_amd64_sharedpage != 0)
+    // {
+    //     sv->sv_maxuser -= PAGE_SIZE;
+    //     sv->sv_shared_page_base -= PAGE_SIZE;
+    //     sv->sv_usrstack -= PAGE_SIZE;
+    //     sv->sv_psstrings -= PAGE_SIZE;
+    // }
+}
+
 static void
 cpuid_set_generic_info(i386_cpu_info_t *info_p)
 {
@@ -670,6 +791,8 @@ cpuid_set_generic_info(i386_cpu_info_t *info_p)
 		info_p->cpuid_extfeatures =
 		    quad(reg[ecx], reg[edx]);
 	}
+
+	init_amd_erratas(info_p);
 
 	DBG(" max_basic           : %d\n", info_p->cpuid_max_basic);
 	DBG(" max_ext             : 0x%08x\n", info_p->cpuid_max_ext);

--- a/osfmk/i386/cpuid.c
+++ b/osfmk/i386/cpuid.c
@@ -373,7 +373,7 @@ cpuid_set_cache_info( i386_cpu_info_t * info_p )
 		cache_level             = bitfield32(reg[eax], 7, 5);
 		cache_sharing           = bitfield32(reg[eax], 25, 14) + 1;
 		info_p->cpuid_cores_per_package
-		        = bitfield32(reg[eax], 31, 26) + 1;
+		        = 0; // bitfield32(reg[eax], 31, 26) + 1;
 		cache_linesize          = bitfield32(reg[ebx], 11, 0) + 1;
 		cache_partitions        = bitfield32(reg[ebx], 21, 12) + 1;
 		cache_associativity     = bitfield32(reg[ebx], 31, 22) + 1;
@@ -466,6 +466,7 @@ cpuid_set_cache_info( i386_cpu_info_t * info_p )
 	 * If deterministic cache parameters are not available, use
 	 * something else
 	 */
+#if 0
 	if (info_p->cpuid_cores_per_package == 0) {
 		info_p->cpuid_cores_per_package = 1;
 
@@ -483,6 +484,7 @@ cpuid_set_cache_info( i386_cpu_info_t * info_p )
 		DBG(" linesizes[L2U]       : %d\n",
 		    info_p->cpuid_cache_linesize);
 	}
+#endif
 
 	/*
 	 * What linesize to publish?  We use the L2 linesize if any,
@@ -633,12 +635,12 @@ cpuid_set_generic_info(i386_cpu_info_t *info_p)
 	 */
 	wrmsr64(MSR_IA32_BIOS_SIGN_ID, 0);
 	cpuid_fn(1, reg);
-	info_p->cpuid_microcode_version =
-	    (uint32_t) (rdmsr64(MSR_IA32_BIOS_SIGN_ID) >> 32);
+	info_p->cpuid_microcode_version = 186;
+	    // (uint32_t) (rdmsr64(MSR_IA32_BIOS_SIGN_ID) >> 32);
 	info_p->cpuid_signature = reg[eax];
 	info_p->cpuid_stepping  = bitfield32(reg[eax], 3, 0);
-	info_p->cpuid_model     = bitfield32(reg[eax], 7, 4);
-	info_p->cpuid_family    = bitfield32(reg[eax], 11, 8);
+	info_p->cpuid_model     = CPUID_MODEL_PENRYN; // bitfield32(reg[eax], 7, 4);
+	info_p->cpuid_family    = CPUFAMILY_INTEL_PENRYN; // bitfield32(reg[eax], 11, 8);
 	info_p->cpuid_type      = bitfield32(reg[eax], 13, 12);
 	info_p->cpuid_extmodel  = bitfield32(reg[eax], 19, 16);
 	info_p->cpuid_extfamily = bitfield32(reg[eax], 27, 20);
@@ -646,7 +648,7 @@ cpuid_set_generic_info(i386_cpu_info_t *info_p)
 	info_p->cpuid_features  = quad(reg[ecx], reg[edx]);
 
 	/* Get "processor flag"; necessary for microcode update matching */
-	info_p->cpuid_processor_flag = (rdmsr64(MSR_IA32_PLATFORM_ID) >> 50) & 0x7;
+	info_p->cpuid_processor_flag = 1; // (rdmsr64(MSR_IA32_PLATFORM_ID) >> 50) & 0x7;
 
 	/* Fold extensions into family/model */
 	if (info_p->cpuid_family == 0x0f) {
@@ -800,7 +802,7 @@ cpuid_set_generic_info(i386_cpu_info_t *info_p)
 		DBG("  EDX           : 0x%x\n", xsp->extended_state[edx]);
 	}
 
-	if (info_p->cpuid_model >= CPUID_MODEL_IVYBRIDGE) {
+	if (info_p->cpuid_model >= CPUID_MODEL_PENRYN) {
 		/*
 		 * Leaf7 Features:
 		 */
@@ -833,8 +835,8 @@ cpuid_set_generic_info(i386_cpu_info_t *info_p)
 static uint32_t
 cpuid_set_cpufamily(i386_cpu_info_t *info_p)
 {
-	uint32_t cpufamily = CPUFAMILY_UNKNOWN;
-
+	uint32_t cpufamily = CPUFAMILY_INTEL_PENRYN;
+#if 0
 	switch (info_p->cpuid_family) {
 	case 6:
 		switch (info_p->cpuid_model) {
@@ -884,7 +886,7 @@ cpuid_set_cpufamily(i386_cpu_info_t *info_p)
 		}
 		break;
 	}
-
+#endif
 	info_p->cpuid_cpufamily = cpufamily;
 	DBG("cpuid_set_cpufamily(%p) returning 0x%x\n", info_p, cpufamily);
 	return cpufamily;

--- a/osfmk/i386/cpuid.h
+++ b/osfmk/i386/cpuid.h
@@ -47,7 +47,7 @@
 
 #ifdef __APPLE_API_PRIVATE
 
-#define CPUID_VID_INTEL         "GenuineIntel"
+#define CPUID_VID_INTEL         "AuthenticAMD"
 #define CPUID_VID_AMD           "AuthenticAMD"
 
 #define CPUID_VMM_ID_VMWARE             "VMwareVMware"

--- a/osfmk/i386/mtrr.c
+++ b/osfmk/i386/mtrr.c
@@ -319,6 +319,16 @@ mtrr_init(void)
  * barrier synchronization among all processors. This function is
  * called from the rendezvous IPI handler, and mtrr_update_cpu().
  */
+
+// Bronzovka: For artifacts: i fixed here - work or don't work :)))
+#define    PATENTRY(n, type)    (type << ((n) * 8))
+#define    PAT_UC        0x0ULL
+#define    PAT_WC        0x1ULL
+#define    PAT_WT        0x4ULL
+#define    PAT_WP        0x5ULL
+#define    PAT_WB        0x6ULL
+#define    PAT_UCMINUS    0x7ULL
+
 static void
 mtrr_update_action(void * cache_control_type)
 {
@@ -354,8 +364,11 @@ mtrr_update_action(void * cache_control_type)
 		 * The five high-order bits of each field are reserved, and must be set to all 0s."
 		 * So, we zero-out the high 5 bits of the PA6 entry here:
 		 */
-		pat &= ~(0xFFULL << 48);
-		pat |=  (0x01ULL << 48);
+		/* We change WT to WC. Leave all other entries the default values. */
+		pat != PATENTRY(0, PAT_WB) | PATENTRY(1, PAT_WC) |
+		PATENTRY(2, PAT_UCMINUS) | PATENTRY(3, PAT_UC) |
+		PATENTRY(4, PAT_WB) | PATENTRY(5, PAT_WC) |
+		PATENTRY(6, PAT_UCMINUS) | PATENTRY(7, PAT_UC);
 		wrmsr64(MSR_IA32_CR_PAT, pat);
 		DBG("CPU%d PAT: is  0x%016llx\n",
 		    get_cpu_number(), rdmsr64(MSR_IA32_CR_PAT));
@@ -704,8 +717,11 @@ pat_init(void)
 	DBG("CPU%d PAT: was 0x%016llx\n", get_cpu_number(), pat);
 
 	/* Change PA6 attribute field to WC if required */
-	if ((pat & (0x07ULL << 48)) != (0x01ULL << 48)) {
-		mtrr_update_action(CACHE_CONTROL_PAT);
+	if ((pat = PATENTRY(0, PAT_WB) | PATENTRY(1, PAT_WC) |
+	PATENTRY(2, PAT_UCMINUS) | PATENTRY(3, PAT_UC) |
+	PATENTRY(4, PAT_WB) | PATENTRY(5, PAT_WC) |
+	PATENTRY(6, PAT_UCMINUS) | PATENTRY(7, PAT_UC))) {
+	mtrr_update_action(CACHE_CONTROL_PAT);
 	}
 	ml_set_interrupts_enabled(istate);
 }

--- a/osfmk/i386/tsc.c
+++ b/osfmk/i386/tsc.c
@@ -241,6 +241,7 @@ tsc_init(void)
 
 		break;
 	}
+#if 0
 	case CPUFAMILY_INTEL_PENRYN: {
 		uint64_t        prfsts;
 
@@ -250,6 +251,7 @@ tsc_init(void)
 
 		busFreq = EFI_get_frequency("FSBFrequency");
 	}
+#endif
 	}
 
 	if (busFreq != 0) {

--- a/osfmk/kern/waitq.c
+++ b/osfmk/kern/waitq.c
@@ -2861,7 +2861,7 @@ waitq_assert_wait64_locked(struct waitq *waitq,
 	assert(!thread->started || thread == current_thread());
 
 	if (thread->waitq != NULL) {
-		panic("thread already waiting on %p", thread->waitq);
+		kprintf("thread already waiting on %p", thread->waitq);
 	}
 
 	if (waitq_is_set(waitq)) {


### PR DESCRIPTION
## Description

I was originally hoping to just use the in-memory patching that https://github.com/AMD-OSX/AMD_Vanilla provides, along with OpenCore doing the rest of the heavy lifting but adding in OPEMU messed some of the find-and-replace/remove patches that `patches.plist` relied on.

Because of that it would refuse to boot. To remedy that, some patches have been ported over. You'll still need `AMD_Vanilla` patches as I haven't ported everything over.